### PR TITLE
Fix NaN error in badge

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ async function run() {
   const head = JSON.parse(await readFile(coverageFilename, "utf8"));
 
   const pct = average(
-    Object.keys(head.total).map((t) => head.total[t].pct),
+    Object.keys(head.total).map((t) => head.total[t].pct).filter(Number.isFinite),
     0
   );
 


### PR DESCRIPTION
I recently encountered a problem in the badge generation displaying a NaN instead of the real coverage.  
The thing is that my json summary is populated with a fifth section called `branchesTrue` that has a `pct` field with the value `"Unknown"`.  
After a bit of research I can't find anything about it and how to get rid of this property.

Anyway, adding a simple filter on the `pct` value list before computing the average value would solve this problem. Filtering those values before calling `average` is generally a good idea and would make the algorithm more fault tolerant.

Here is a example of what I got:
```json
{
  "total": {
    "lines": {
      "total": 479,
      "covered": 479,
      "skipped": 0,
      "pct": 100
    },
    "statements": {
      "total": 479,
      "covered": 479,
      "skipped": 0,
      "pct": 100
    },
    "functions": {
      "total": 15,
      "covered": 15,
      "skipped": 0,
      "pct": 100
    },
    "branches": {
      "total": 34,
      "covered": 29,
      "skipped": 0,
      "pct": 85.29
    },
    "branchesTrue": {
      "total": 0,
      "covered": 0,
      "skipped": 0,
      "pct": "Unknown"
    }
  }
}
```