### PR TITLE
chore: updated version of node

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ inputs:
     default: "70"
     required: false
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Github actions are triggering the following warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: greatwizard/coverage-diff-action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

This PR is updating the node version of the action from 16 to 20.